### PR TITLE
fix: jschlTk is empty when has query in request url

### DIFF
--- a/src/catchCloudflare.ts
+++ b/src/catchCloudflare.ts
@@ -147,7 +147,7 @@ export function getRValue(body: string): object {
 }
 
 export function getJschlTk(body: string): string {
-  const exp = /\?__cf_chl_jschl_tk__=(\S+)"/gm;
+  const exp = /[?;]__cf_chl_jschl_tk__=(\S+)"/gm;
   const result = exp.exec(body);
   if (result && result.length) {
     return result[1];


### PR DESCRIPTION
```html
<form class="challenge-form" id="challenge-form" action="/?search=westworld&amp;__cf_chl_jschl_tk__=7e4206d1c4dec9b6c01727ac89aa4e4f9e24159c-1588402479-0-AeqhyiuPc_0iMEPt7_5m89mRlmMJlEEaxlPON-2tB9m_W1EP4Kzovm2Jey32IXRYMPx1Gfn3H9sy82WrxYbpsH1grLnSeBtMOl8mjxCjE_VW2WEmPFozawsfrEUjg2iJ4sV7jpHPcOEoXSaRLn8AOv7uZedSFYULUA-74ujdDCbRgn5heRo9pp0I3Y-bkpP1-2y9XsptawKoOTYZFNyGzpVZ-zPIcmEYA9LqToH907U8TthwthVruw9EfzLaWla4E4JvT9rxL358QnuMZrbl8lfUT2XOixvl1f4W8gzg-9Dm" method="POST" enctype="application/x-www-form-urlencoded">
```